### PR TITLE
Upgrade to Zeebe 0.21.1 and handle gRPC status exceptions

### DIFF
--- a/.ci/scripts/github-release.sh
+++ b/.ci/scripts/github-release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -xeu
+
+cd target
+
+export GITHUB_TOKEN=${GITHUB_TOKEN_PSW}
+export GITHUB_ORG=zeebe-io
+export GITHUB_REPO=kafka-connect-zeebe
+export ARTIFACT=kafka-connect-zeebe-${RELEASE_VERSION}-uber.jar
+export CHECKSUM=${ARTIFACT}.sha1sum
+
+# create checksum files
+sha1sum ${ARTIFACT} > ${CHECKSUM}
+
+# do github release
+curl -sL https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 | tar xjvf - --strip 3
+
+./github-release release --user ${GITHUB_ORG} --repo ${GITHUB_REPO} --tag ${RELEASE_VERSION} --draft --name "Zeebe Exporter Protobuf ${RELEASE_VERSION}" --description ""
+./github-release upload --user ${GITHUB_ORG} --repo ${GITHUB_REPO} --tag ${RELEASE_VERSION} --name "${ARTIFACT}" --file "${ARTIFACT}"
+./github-release upload --user ${GITHUB_ORG} --repo ${GITHUB_REPO} --tag ${RELEASE_VERSION} --name "${CHECKSUM}" --file "${CHECKSUM}"

--- a/.ci/settings.xml
+++ b/.ci/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>camunda-nexus</id>
+      <username>${env.NEXUS_USR}</username>
+      <password>${env.NEXUS_PSW}</password>
+    </server>
+    <server>
+      <id>central</id>
+      <username>${env.MAVEN_CENTRAL_USR}</username>
+      <password>${env.MAVEN_CENTRAL_PSW}</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>camunda-nexus</id>
+      <mirrorOf>*</mirrorOf>
+      <name>Camunda Nexus</name>
+      <!-- uncomment to use DC Nexus locally
+      <url>https://app.camunda.com/nexus/content/groups/internal</url>
+      -->
+      <!-- use CI proxy nexus -->
+      <url>http://repository-ci-camunda-cloud.nexus:8081/content/groups/internal/</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,134 @@
+pipeline {
+
+  agent {
+    kubernetes {
+      cloud 'zeebe-ci'
+      label "zeebe-ci-build_${env.JOB_BASE_NAME}-${env.BUILD_ID}"
+      defaultContainer 'jnlp'
+      yaml '''\
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    agent: zeebe-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: slaves
+  tolerations:
+    - key: "slaves"
+      operator: "Exists"
+      effect: "NoSchedule"
+  containers:
+    - name: maven
+      image: maven:3.6.0-jdk-8
+      command: ["cat"]
+      tty: true
+      env:
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UnlockExperimentalVMOptions
+            -XX:+UseCGroupMemoryLimitForHeap
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 1
+          memory: 1Gi
+'''
+    }
+  }
+
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+    timestamps()
+    timeout(time: 15, unit: 'MINUTES')
+  }
+
+  environment {
+    NEXUS = credentials("camunda-nexus")
+  }
+
+  parameters {
+    booleanParam(name: 'RELEASE', defaultValue: false, description: 'Build a release from current commit?')
+    string(name: 'RELEASE_VERSION', defaultValue: '0.X.0', description: 'Which version to release?')
+    string(name: 'DEVELOPMENT_VERSION', defaultValue: '0.Y.0-SNAPSHOT', description: 'Next development version?')
+  }
+
+  stages {
+    stage('Prepare') {
+      steps {
+        container('maven') {
+            sh 'mvn clean install -B -s .ci/settings.xml -DskipTests'
+        }
+      }
+    }
+
+    stage('Build') {
+      when { not { expression { params.RELEASE } } }
+      steps {
+        container('maven') {
+            sh 'mvn install -B -s .ci/settings.xml'
+        }
+      }
+
+      post {
+        always {
+            junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
+        }
+      }
+    }
+
+    stage('Upload') {
+      when { not { expression { params.RELEASE } } }
+      steps {
+        container('maven') {
+            sh 'mvn -B -s .ci/settings.xml generate-sources source:jar javadoc:jar deploy -DskipTests'
+        }
+      }
+    }
+
+    stage('Release') {
+      when { expression { params.RELEASE } }
+
+      environment {
+        MAVEN_CENTRAL = credentials('maven_central_deployment_credentials')
+        GPG_PASS = credentials('password_maven_central_gpg_signing_key')
+        GPG_PUB_KEY = credentials('maven_central_gpg_signing_key_pub')
+        GPG_SEC_KEY = credentials('maven_central_gpg_signing_key_sec')
+        GITHUB_TOKEN = credentials('camunda-jenkins-github')
+        RELEASE_VERSION = "${params.RELEASE_VERSION}"
+        DEVELOPMENT_VERSION = "${params.DEVELOPMENT_VERSION}"
+      }
+
+      steps {
+        container('maven') {
+          sshagent(['camunda-jenkins-github-ssh']) {
+            sh 'gpg -q --import ${GPG_PUB_KEY} '
+            sh 'gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}'
+            sh 'git config --global user.email "ci@camunda.com"'
+            sh 'git config --global user.name "camunda-jenkins"'
+            sh 'mkdir ~/.ssh/ && ssh-keyscan github.com >> ~/.ssh/known_hosts'
+            sh 'mvn -B -s .ci/settings.xml -DskipTests source:jar javadoc:jar release:prepare release:perform -Prelease'
+            sh '.ci/scripts/github-release.sh'
+          }
+        }
+      }
+    }
+  }
+
+  post {
+      always {
+          // Retrigger the build if the node disconnected
+          script {
+              if (nodeDisconnected()) {
+                  build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
+              }
+          }
+      }
+  }
+}
+
+boolean nodeDisconnected() {
+  return currentBuild.rawBuild.getLog(500).join('') ==~ /.*(ChannelClosedException|KubernetesClientException|ClosedChannelException).*/
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This [Kafka Connect](https://docs.confluent.io/current/connect/index.html) connector for [Zeebe](https://zeebe.io) can do two things:
 
-* **Send messages to a Kafka topic** when a workflow instance reached a specific activity. Please note that a `message` is more precisly a kafka `record`, which is also often named `event`. This is a **source** in the Kafka Connect speak. 
+* **Send messages to a Kafka topic** when a workflow instance reached a specific activity. Please note that a `message` is more precisly a kafka `record`, which is also often named `event`. This is a **source** in the Kafka Connect speak.
 
 * **Consume messages from a Kafka topic and correlate them to a workflow**. This is a Kafka Connect **sink**.
 
@@ -23,7 +23,7 @@ You will find information on **how to build the connector** and **how to run Kaf
 
 # Connectors
 
-The plugin comes with two connectors, a source and a sink connector. 
+The plugin comes with two connectors, a source and a sink connector.
 
 The source connector activates Zeebe jobs, publishes them as Kafka records, and completes them once they have been committed to Kafka.
 
@@ -32,10 +32,10 @@ The source connector activates Zeebe jobs, publishes them as Kafka records, and 
 In a workflow model you can wait for certain events by name (extracted from the payload by messageNameJsonPath):
 
 ![Overview](doc/images/sink-example.png)
- 
+
 The sink connector consumes Kafka records and publishes messages constructed from those records to Zeebe.
 This uses the [Zeebe Message Correlation](https://docs.zeebe.io/reference/message-correlation.html) features.
-So for example if no matching workflow instance is found, the message is buffered for its time-to-live (TTL) and then discarded. 
+So for example if no matching workflow instance is found, the message is buffered for its time-to-live (TTL) and then discarded.
 You could simply ingest all messages from a Kafka topic and check if they correlate to something in Zeebe.
 
 ### Configuration
@@ -44,8 +44,9 @@ In order to communicate with Zeebe, the connector has to create a Zeebe client, 
 
 - `zeebe.client.broker.contactPoint`: the Zeebe broker address, specified as `host:port`; defaults to `localhost:26500`
 - `zeebe.client.requestTimeout`: timeout in milliseconds for requests to the Zeebe broker; defaults to `10000` (or 10 seconds)
+- `zeebe.client.security.plaintext`: disable secure connections to the gateway for local development setups
 
-> For client and job worker configuration, we reuse the system properties as used by Zeebe, so if you already have a properties file 
+> For client and job worker configuration, we reuse the system properties as used by Zeebe, so if you already have a properties file
   for those they should simply work.
 
 The connector does not yet support [schemas](https://docs.confluent.io/current/schema-registry/connect.html), and currently expect
@@ -78,9 +79,9 @@ In order to communicate with Zeebe, the connector has to create a Zeebe client, 
 - `zeebe.client.broker.contactPoint`: the Zeebe broker address, specified as `host:port`; defaults to `localhost:26500`
 - `zeebe.client.requestTimeout`: timeout in milliseconds for requests to the Zeebe broker; defaults to `10000` (or 10 seconds)
 
-> For client and job worker configuration, we reuse the system properties as used by Zeebe, so if you already have a properties file 
+> For client and job worker configuration, we reuse the system properties as used by Zeebe, so if you already have a properties file
   for those they should simply work.
-  
+
 - `zeebe.client.worker.maxJobsActive`: the maximum number of jobs that the worker can activate in a single request; defaults to `100`
 - `zeebe.client.job.worker`: the worker name; defaults to `kafka-connector`
 - `zeebe.client.job.timeout`: how long before a job activated by the worker is made activatable again to others, in milliseconds; defaults to `5000` (or 5 seconds)
@@ -103,8 +104,8 @@ If this custom header is not present, then all variables in the scope will be se
 
 This project is set up to be released on Confluent Hub.
 
-When 
-* Building this project via `mvn package` 
+When
+* Building this project via `mvn package`
 * You will find the plugin package as ZIP file under `target/components/packages`, e.g. `target/components/packages/zeebe-io-kafka-connect-zeebe-1.0.0.zip`
 * Which can be [installed onto the Confluent Hub](https://docs.confluent.io/current/connect/managing/install.html#connect-install-connectors)
 

--- a/config/quickstart-zeebe-sink.properties
+++ b/config/quickstart-zeebe-sink.properties
@@ -30,6 +30,7 @@ value.converter.schemas.enable=false
 # Connector specific settings
 zeebe.client.broker.contactPoint=localhost:26500
 zeebe.client.requestTimeout=10000
+zeebe.client.security.plaintext=true
 
 message.path.correlationKey=$.correlationKey
 message.path.messageName=$.messageName

--- a/config/quickstart-zeebe-source.properties
+++ b/config/quickstart-zeebe-source.properties
@@ -28,6 +28,7 @@ value.converter.schemas.enable=false
 
 # Connector specific settings
 zeebe.client.broker.contactPoint=localhost:26500
+zeebe.client.security.plaintext=true
 zeebe.client.worker.maxJobsActive=100
 zeebe.client.job.worker=kafka-connector
 zeebe.client.job.timeout=5000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,23 +2,25 @@ version: '2.1'
 
 services:
   zeebe:
-    image: camunda/zeebe:0.20.0
+    image: camunda/zeebe:0.21.1
     hostname: zeebe
     ports:
       - "26500:26500"
       - "9600:9600"
     volumes:
       - ./zeebe.cfg.toml:/usr/local/zeebe/conf/zeebe.cfg.toml
+    environment:
+      ZEEBE_INSECURE_CONNECTION: "true"
 
   operate:
-    image: camunda/operate:1.0.0
+    image: camunda/operate:1.1.0
     ports:
       - "8080:8080"
     volumes:
       - ./operate.yml:/usr/local/operate/config/application.yml
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.3
     ports:
       - "9200:9200"
     environment:

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,14 +44,14 @@ docker-compose up
 will start:
 
 - [Zeebe](https://zeebe.io), on port `26500` for the client, and port `9600` for monitoring.
-    - To check if your Zeebe instance is ready, you can check [http://localhost:9600/ready](http://localhost:9600/ready), 
+    - To check if your Zeebe instance is ready, you can check [http://localhost:9600/ready](http://localhost:9600/ready),
       which will return a `204` response if ready.
 - [Kafka](https://kafka.apache.org/), on port `9092`.
     - [Zookeeper](https://zookeeper.apache.org/), on port `2081`.
 - [Kafka Schema Registry](https://docs.confluent.io/current/schema-registry/index.html), on port `8081`.
 - [Kafka Connect](https://docs.confluent.io/current/connect/index.html), on port `8083`.
 - Monitoring tools
-    - [Operate](https://github.com/zeebe-io/zeebe/releases/tag/0.20.0), a [monitoring tool for Zeebe](https://zeebe.io/blog/2019/04/announcing-operate-visibility-and-problem-solving/), on port `8080`.
+    - [Operate](https://github.com/zeebe-io/zeebe/releases/tag/0.21.1), a [monitoring tool for Zeebe](https://zeebe.io/blog/2019/04/announcing-operate-visibility-and-problem-solving/), on port `8080`.
         - Operate has an external dependency on [Elasticsearch](https://www.elastic.co/), which we'll also run on port `9200`.
     - [Confluent Control Center](https://www.confluent.io/confluent-control-center/), on port `9021`. This will be our tool to monitor the Kafka cluster, create connectors, visualize Kafka topics, etc.
 

--- a/examples/microservices-orchestration/payment-sink.json
+++ b/examples/microservices-orchestration/payment-sink.json
@@ -8,6 +8,7 @@
     "topics": "payment-confirm",
     "zeebe.client.broker.contactPoint": "zeebe:26500",
     "zeebe.client.requestTimeout": "10000",
+    "zeebe.client.security.plaintext": true,
     "message.path.messageName": "$.eventType",
     "message.path.correlationKey": "$.orderId",
     "message.path.variables": "$.['amount', 'orderId']"

--- a/examples/microservices-orchestration/payment-source.json
+++ b/examples/microservices-orchestration/payment-source.json
@@ -7,6 +7,7 @@
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "zeebe.client.broker.contactPoint": "zeebe:26500",
     "zeebe.client.requestTimeout": "10000",
+    "zeebe.client.security.plaintext": true,
     "zeebe.client.job.worker": "kafka-connector",
     "zeebe.client.worker.maxJobsActive": "100",
     "zeebe.client.job.pollinterval": "2000",

--- a/examples/ping-pong/README.md
+++ b/examples/ping-pong/README.md
@@ -10,7 +10,7 @@ source connector `ping`, which will publish a record on the topic `pong`. That r
 the job key as its key, and as value the job itself serialized to JSON.
 
 The `pong` sink connector will consume records from the `pong` topic, and publish a message to
-its Zeebe broker. For example, given the following record published to `pong` on partition 1, 
+its Zeebe broker. For example, given the following record published to `pong` on partition 1,
 at offset 1, and with the following value:
 
 ```json
@@ -69,13 +69,13 @@ make workflow source sink
 To create the instance, run:
 
 ```shell
-make instance
+make ping
 ```
 ### Manually
 
 If `make` is not available on your system then you can run steps manually:
 
-#### Deploy workflow 
+#### Deploy workflow
 
 ```shell
 docker-compose -f docker/docker-compose.yml exec zeebe \

--- a/examples/ping-pong/sink.json
+++ b/examples/ping-pong/sink.json
@@ -10,6 +10,7 @@
     "topics": "pong",
     "zeebe.client.broker.contactPoint": "zeebe:26500",
     "zeebe.client.requestTimeout": "10000",
+    "zeebe.client.security.plaintext": true,
     "message.path.messageName": "$.variablesAsMap.name",
     "message.path.correlationKey": "$.variablesAsMap.key",
     "message.path.variables": "$.variablesAsMap.payload",

--- a/examples/ping-pong/source.json
+++ b/examples/ping-pong/source.json
@@ -9,6 +9,7 @@
     "value.converter.schemas.enable": false,
     "zeebe.client.broker.contactPoint": "zeebe:26500",
     "zeebe.client.requestTimeout": "10000",
+    "zeebe.client.security.plaintext": true,
     "zeebe.client.job.worker": "kafka-connector",
     "zeebe.client.worker.maxJobsActive": "100",
     "zeebe.client.job.pollinterval": "2000",

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <version.jsonpath>2.4.0</version.jsonpath>
     <version.log4j>2.12.0</version.log4j>
     <version.slf4j>1.7.26</version.slf4j>
-    <version.zeebe>0.20.0</version.zeebe>
+    <version.zeebe>0.21.1</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.assembly>3.1.1</plugin.version.assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-protocol</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>${version.jsonpath}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,10 @@
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 
     <!-- project dependencies -->
+    <version.assertj>3.14.0</version.assertj>
     <version.kafka>2.3.0</version.kafka>
     <version.jsonpath>2.4.0</version.jsonpath>
+    <version.junit>5.5.2</version.junit>
     <version.log4j>2.12.0</version.log4j>
     <version.slf4j>1.7.26</version.slf4j>
     <version.zeebe>0.21.1</version.zeebe>
@@ -115,6 +117,21 @@
       <version>${version.log4j}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.assertj}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkConnectorConfig.java
+++ b/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkConnectorConfig.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
 public class ZeebeSinkConnectorConfig extends AbstractConfig {
+  public static final ConfigDef DEFINITIONS = defineConfiguration();
+
   static final String MESSAGE_PATH_KEY_CONFIG = "message.path.correlationKey";
   static final String MESSAGE_PATH_NAME_CONFIG = "message.path.messageName";
   static final String MESSAGE_PATH_TTL_CONFIG = "message.path.timeToLive";
@@ -42,8 +44,6 @@ public class ZeebeSinkConnectorConfig extends AbstractConfig {
   private static final String MESSAGE_PATH_VARIABLES_DEFAULT = "variables";
   private static final String MESSAGE_PATH_VARIABLES_DOC =
       "JSON path expression to extract message variables";
-
-  public static final ConfigDef DEFINITIONS = defineConfiguration();
 
   public ZeebeSinkConnectorConfig(final Map<String, String> properties) {
     super(DEFINITIONS, properties);

--- a/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkFuture.java
+++ b/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkFuture.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.kafka.connect.sink;
+
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.zeebe.client.api.command.FinalCommandStep;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ZeebeSinkFuture extends CompletableFuture<Void> {
+
+  public static final Set<Code> SUCCESS_CODES = EnumSet.of(Code.OK, Code.ALREADY_EXISTS);
+  public static final Set<Code> RETRIABLE_CODES =
+      EnumSet.of(
+          Code.CANCELLED,
+          Code.DEADLINE_EXCEEDED,
+          Code.RESOURCE_EXHAUSTED,
+          Code.ABORTED,
+          Code.UNAVAILABLE,
+          Code.DATA_LOSS);
+  public static final Set<Code> FAILURE_CODES =
+      EnumSet.of(
+          Code.INVALID_ARGUMENT,
+          Code.NOT_FOUND,
+          Code.PERMISSION_DENIED,
+          Code.FAILED_PRECONDITION,
+          Code.OUT_OF_RANGE,
+          Code.UNIMPLEMENTED,
+          Code.INTERNAL,
+          Code.UNAUTHENTICATED);
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeSinkFuture.class);
+
+  private final FinalCommandStep<Void> command;
+
+  ZeebeSinkFuture(final FinalCommandStep<Void> command) {
+    this.command = command;
+  }
+
+  @SuppressWarnings("unchecked")
+  private CompletableFuture<Void> sendCommand() {
+    return (CompletableFuture<Void>) command.send();
+  }
+
+  CompletableFuture<Void> executeAsync() {
+    sendCommand()
+        .whenCompleteAsync(
+            (aVoid, throwable) -> {
+              if (throwable == null) {
+                this.complete(aVoid);
+              } else if (throwable instanceof StatusRuntimeException) {
+                // handle gRPC errors
+                final StatusRuntimeException statusException = (StatusRuntimeException) throwable;
+                final Code code = statusException.getStatus().getCode();
+                if (SUCCESS_CODES.contains(code)) {
+                  complete(null);
+                } else if (RETRIABLE_CODES.contains(code)) {
+                  executeAsync();
+                } else if (FAILURE_CODES.contains(code)) {
+                  completeExceptionally(throwable);
+                } else {
+                  LOGGER.warn("Unexpected gRPC status code {} received", code, throwable);
+                  completeExceptionally(throwable);
+                }
+              } else {
+                completeExceptionally(throwable);
+              }
+            });
+
+    return this;
+  }
+}

--- a/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkTask.java
+++ b/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkTask.java
@@ -83,7 +83,8 @@ public class ZeebeSinkTask extends SinkTask {
         sinkRecords
             .stream()
             .map(r -> this.preparePublishRequest(client, r))
-            .map(FinalCommandStep::send)
+            .map(ZeebeSinkFuture::new)
+            .map(ZeebeSinkFuture::executeAsync)
             .toArray(CompletableFuture[]::new);
 
     return CompletableFuture.allOf(inFlightRequests);

--- a/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkTask.java
+++ b/src/main/java/io/zeebe/kafka/connect/sink/ZeebeSinkTask.java
@@ -16,6 +16,7 @@
 package io.zeebe.kafka.connect.sink;
 
 import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep3;
 import io.zeebe.kafka.connect.sink.message.JsonRecordParser;
@@ -113,10 +114,16 @@ public class ZeebeSinkTask extends SinkTask {
   private ZeebeClient buildClient(final ZeebeSinkConnectorConfig config) {
     final long requestTimeoutMs = config.getLong(ZeebeClientConfigDef.REQUEST_TIMEOUT_CONFIG);
 
-    return ZeebeClient.newClientBuilder()
-        .brokerContactPoint(config.getString(ZeebeClientConfigDef.BROKER_CONTACTPOINT_CONFIG))
-        .defaultRequestTimeout(Duration.ofMillis(requestTimeoutMs))
-        .build();
+    final ZeebeClientBuilder zeebeClientBuilder =
+        ZeebeClient.newClientBuilder()
+            .brokerContactPoint(config.getString(ZeebeClientConfigDef.BROKER_CONTACTPOINT_CONFIG))
+            .defaultRequestTimeout(Duration.ofMillis(requestTimeoutMs));
+
+    if (config.getBoolean(ZeebeClientConfigDef.USE_PLAINTEXT_CONFIG)) {
+      zeebeClientBuilder.usePlaintext();
+    }
+
+    return zeebeClientBuilder.build();
   }
 
   private JsonRecordParser buildParser(final ZeebeSinkConnectorConfig config) {

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceConnectorConfig.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceConnectorConfig.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
 public class ZeebeSourceConnectorConfig extends AbstractConfig {
+  public static final ConfigDef DEFINITIONS = createDefinitions();
   public static final String JOB_TYPES_CONFIG = "job.types";
   static final String WORKER_NAME_CONFIG = ClientProperties.DEFAULT_JOB_WORKER_NAME;
   static final String MAX_JOBS_TO_ACTIVATE_CONFIG = ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE;
@@ -32,7 +33,6 @@ public class ZeebeSourceConnectorConfig extends AbstractConfig {
   static final String JOB_TIMEOUT_CONFIG = ClientProperties.DEFAULT_JOB_TIMEOUT;
   static final String JOB_HEADER_TOPICS_CONFIG = "job.header.topics";
   static final String JOB_VARIABLES_CONFIG = "job.variables";
-
   private static final String WORKER_CONFIG_GROUP = "Job Worker";
   private static final String WORKER_NAME_DEFAULT = "kafka-connector";
   private static final String WORKER_NAME_DOC = "Name of the Zeebe worker that will poll jobs";
@@ -57,7 +57,6 @@ public class ZeebeSourceConnectorConfig extends AbstractConfig {
   private static final String JOB_VARIABLES_DOC =
       "A comma-separated list of variables to fetch when activating a job. If none given, then "
           + "all variables are fetched.";
-  public static final ConfigDef DEFINITIONS = createDefinitions();
 
   public ZeebeSourceConnectorConfig(final Map<String, String> properties) {
     super(DEFINITIONS, properties);

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
@@ -16,6 +16,7 @@
 package io.zeebe.kafka.connect.source;
 
 import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.ActivatedJob;
 import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.api.worker.JobWorker;
@@ -134,10 +135,16 @@ public class ZeebeSourceTask extends SourceTask {
   }
 
   private ZeebeClient buildClient(final ZeebeSourceConnectorConfig config) {
-    return ZeebeClient.newClientBuilder()
-        .brokerContactPoint(config.getString(ZeebeClientConfigDef.BROKER_CONTACTPOINT_CONFIG))
-        .numJobWorkerExecutionThreads(1)
-        .build();
+    final ZeebeClientBuilder zeebeClientBuilder =
+        ZeebeClient.newClientBuilder()
+            .brokerContactPoint(config.getString(ZeebeClientConfigDef.BROKER_CONTACTPOINT_CONFIG))
+            .numJobWorkerExecutionThreads(1);
+
+    if (config.getBoolean(ZeebeClientConfigDef.USE_PLAINTEXT_CONFIG)) {
+      zeebeClientBuilder.usePlaintext();
+    }
+
+    return zeebeClientBuilder.build();
   }
 
   private SourceRecord transformJob(final ActivatedJob job) {

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
@@ -67,7 +67,8 @@ public class ZeebeSourceTask extends SourceTask {
     maxJobsToActivate = config.getInt(ZeebeSourceConnectorConfig.MAX_JOBS_TO_ACTIVATE_CONFIG);
     managedClient = new ManagedClient(client);
     workers =
-        jobTypes.stream()
+        jobTypes
+            .stream()
             .map(type -> this.newWorker(config, type, client))
             .collect(Collectors.toList());
   }

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
@@ -23,7 +23,6 @@ import io.zeebe.kafka.connect.util.ManagedClient;
 import io.zeebe.kafka.connect.util.ManagedClient.AlreadyClosedException;
 import io.zeebe.kafka.connect.util.VersionInfo;
 import io.zeebe.kafka.connect.util.ZeebeClientConfigDef;
-import io.zeebe.protocol.Protocol;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -144,7 +143,7 @@ public class ZeebeSourceTask extends SourceTask {
   private SourceRecord transformJob(final ActivatedJob job) {
     final String topic = job.getCustomHeaders().get(jobHeaderTopic);
     final Map<String, Integer> sourcePartition =
-        Collections.singletonMap("partitionId", Protocol.decodePartitionId(job.getKey()));
+        Collections.singletonMap("partitionId", decodePartitionId(job.getKey()));
     // a better sourceOffset would be the position but we don't have it here unfortunately
     // key is however a monotonically increasing value, so in a sense it can provide a good
     // approximation of an offset
@@ -218,5 +217,11 @@ public class ZeebeSourceTask extends SourceTask {
         LOGGER.error("Failed to append job {} to jobs queue", job, e);
       }
     }
+  }
+
+  // Copied from Zeebe Protocol as it is currently fixed to Java 11, and the connector to Java 8
+  // Should be fixed eventually and we can use the protocol directly again
+  private int decodePartitionId(final long key) {
+    return (int) (key >> 51);
   }
 }

--- a/src/main/java/io/zeebe/kafka/connect/util/ZeebeClientConfigDef.java
+++ b/src/main/java/io/zeebe/kafka/connect/util/ZeebeClientConfigDef.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 public final class ZeebeClientConfigDef {
   public static final String BROKER_CONTACTPOINT_CONFIG = ClientProperties.BROKER_CONTACTPOINT;
   public static final String REQUEST_TIMEOUT_CONFIG = ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+  public static final String USE_PLAINTEXT_CONFIG = ClientProperties.USE_PLAINTEXT_CONNECTION;
 
   private static final String CLIENT_CONFIG_GROUP = "Zeebe Client";
   private static final String BROKER_CONTACTPOINT_DEFAULT = "localhost:26500";
@@ -32,6 +33,9 @@ public final class ZeebeClientConfigDef {
   private static final long REQUEST_TIMEOUT_DEFAULT = 10_000;
   private static final String REQUEST_TIMEOUT_DOC =
       "How long to wait before a request to the broker is timed out";
+  private static final boolean USE_PLAINTEXT_DEFAULT = false;
+  private static final String USE_PLAINTEXT_DOC =
+      "Disable secure connection to gateway for the Zeebe client";
 
   private ZeebeClientConfigDef() {}
 
@@ -58,6 +62,16 @@ public final class ZeebeClientConfigDef {
             CLIENT_CONFIG_GROUP,
             ++order,
             Width.SHORT,
-            "Request timeout");
+            "Request timeout")
+        .define(
+            USE_PLAINTEXT_CONFIG,
+            Type.BOOLEAN,
+            USE_PLAINTEXT_DEFAULT,
+            Importance.LOW,
+            USE_PLAINTEXT_DOC,
+            CLIENT_CONFIG_GROUP,
+            ++order,
+            Width.SHORT,
+            "Use plaintext connection");
   }
 }

--- a/src/test/java/io/zeebe/kafka/connect/sink/ZeebeSinkFutureTest.java
+++ b/src/test/java/io/zeebe/kafka/connect/sink/ZeebeSinkFutureTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.kafka.connect.sink;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.command.FinalCommandStep;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class ZeebeSinkFutureTest {
+
+  @Test
+  void shouldCompleteByDefault() {
+    // given
+    final ZeebeSinkFuture future = create(() -> {});
+
+    // when
+    assertThatCode(() -> future.executeAsync().join())
+        // then
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldCompleteExceptionalIfNotStatusException() {
+    // given
+    final String message = "expected test error";
+    final ZeebeSinkFuture future = create(new RuntimeException(message));
+
+    // when
+    assertThatThrownBy(() -> future.executeAsync().join())
+        // then
+        .hasCauseInstanceOf(RuntimeException.class)
+        .hasMessageContaining(message);
+  }
+
+  @Test
+  void shouldCompleteIfAcceptableStatusException() {
+    // given
+    ZeebeSinkFuture.SUCCESS_CODES
+        .stream()
+        .map(this::create)
+        .forEach(
+            future -> {
+              // when
+              assertThatCode(() -> future.executeAsync().join())
+                  // then
+                  .doesNotThrowAnyException();
+            });
+  }
+
+  @Test
+  void shouldCompleteIfRetriableStatusException() {
+    // given
+    ZeebeSinkFuture.RETRIABLE_CODES
+        .stream()
+        .map(this::retriable)
+        .map(this::create)
+        .forEach(
+            future -> {
+              // when
+              assertThatCode(() -> future.executeAsync().join())
+                  // then
+                  .doesNotThrowAnyException();
+            });
+  }
+
+  @Test
+  void shouldCompleteExceptionalIfNonRecoverableStatusException() {
+    // given
+    ZeebeSinkFuture.FAILURE_CODES
+        .stream()
+        .map(this::create)
+        .forEach(
+            future -> {
+              // when
+              assertThatThrownBy(() -> future.executeAsync().join())
+                  // then
+                  .hasCauseInstanceOf(StatusRuntimeException.class);
+            });
+  }
+
+  private Runnable retriable(final Code code) {
+    return new Runnable() {
+      boolean failed = false;
+
+      @Override
+      public void run() {
+        if (!failed) {
+          failed = true;
+          throw new StatusRuntimeException(Status.fromCode(code));
+        }
+      }
+    };
+  }
+
+  private ZeebeSinkFuture create(final Code code) {
+    return create(new StatusRuntimeException(Status.fromCode(code)));
+  }
+
+  private ZeebeSinkFuture create(final RuntimeException e) {
+    return create(
+        () -> {
+          throw e;
+        });
+  }
+
+  private ZeebeSinkFuture create(final Runnable r) {
+    return new ZeebeSinkFuture(new FinalStepMock(r));
+  }
+
+  static class FinalStepMock implements FinalCommandStep<Void> {
+
+    final Runnable mock;
+
+    FinalStepMock(final Runnable r) {
+      this.mock = r;
+    }
+
+    @Override
+    public FinalCommandStep<Void> requestTimeout(final Duration duration) {
+      return this;
+    }
+
+    @Override
+    public ZeebeFuture<Void> send() {
+      final ZeebeFutureMock future = new ZeebeFutureMock();
+      try {
+        mock.run();
+        future.complete(null);
+      } catch (final Exception e) {
+        future.completeExceptionally(e);
+      }
+
+      return future;
+    }
+  }
+
+  static class ZeebeFutureMock extends CompletableFuture<Void> implements ZeebeFuture<Void> {
+
+    @Override
+    public Void join(final long l, final TimeUnit timeUnit) {
+      try {
+        return get(l, timeUnit);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
- upgrade to Zeebe 0.21.1 and Operate 1.1.0
- upgrade to Elasticsearch 6.8.3
- temporary remove zeebe-protocol dependency until https://github.com/zeebe-io/zeebe/issues/3298 is fixed
- add configuration option to disable secure connection to the gateway
- handle gRPC status exceptions
  - retry recoverable exceptions like back pressure or connections issues
  - ignore idempotency exceptions as successful outcome
- add CI pipeline and release build

closes #22 
closes #23