### PR TITLE
feat(ZeebeSourceTask): use manual polling instead of job worker

### DIFF
--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceBackoff.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceBackoff.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.kafka.connect.source;
+
+import io.zeebe.kafka.connect.util.ZeebeClientConfigDef;
+import java.time.Duration;
+
+public class ZeebeSourceBackoff {
+
+  private static final int NO_BACKOFF = -1;
+
+  private final long minBackoff;
+  private final long maxBackoff;
+  private long backoff;
+
+  private ZeebeSourceBackoff(final long minBackoff, final long maxBackoff) {
+    this.minBackoff = minBackoff;
+    this.maxBackoff = maxBackoff;
+    reset();
+  }
+
+  ZeebeSourceBackoff(final ZeebeSourceConnectorConfig config) {
+    this(100, config.getLong(ZeebeClientConfigDef.REQUEST_TIMEOUT_CONFIG));
+  }
+
+  void reset() {
+    backoff = NO_BACKOFF;
+  }
+
+  Duration currentDuration() {
+    return Duration.ofMillis(backoff);
+  }
+
+  private long nextDuration() {
+    final long nextBackoff = Math.max(backoff, minBackoff) * 2;
+    return Math.min(nextBackoff, maxBackoff);
+  }
+
+  void backoff() {
+    backoff = nextDuration();
+    try {
+      Thread.sleep(backoff);
+    } catch (final InterruptedException e) {
+      // ignore
+    }
+  }
+}

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceConnectorConfig.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceConnectorConfig.java
@@ -29,7 +29,6 @@ public class ZeebeSourceConnectorConfig extends AbstractConfig {
   public static final String JOB_TYPES_CONFIG = "job.types";
   static final String WORKER_NAME_CONFIG = ClientProperties.DEFAULT_JOB_WORKER_NAME;
   static final String MAX_JOBS_TO_ACTIVATE_CONFIG = ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE;
-  static final String POLL_INTERVAL_CONFIG = ClientProperties.DEFAULT_JOB_POLL_INTERVAL;
   static final String JOB_TIMEOUT_CONFIG = ClientProperties.DEFAULT_JOB_TIMEOUT;
   static final String JOB_HEADER_TOPICS_CONFIG = "job.header.topics";
   static final String JOB_VARIABLES_CONFIG = "job.variables";
@@ -39,8 +38,6 @@ public class ZeebeSourceConnectorConfig extends AbstractConfig {
   private static final int MAX_JOBS_TO_ACTIVATE_DEFAULT = 100;
   private static final String MAX_JOBS_TO_ACTIVATE_DOC =
       "Maximum number of jobs to fetch at once when a task is polling";
-  private static final long POLL_INTERVAL_DEFAULT = 5000;
-  private static final String POLL_INTERVAL_DOC = "How often the job worker will poll for new jobs";
   private static final long JOB_TIMEOUT_DEFAULT = 5_000;
   private static final String JOB_TIMEOUT_DOC =
       "How long to wait before the job fetched can be seen by another worker; this should be "
@@ -94,16 +91,6 @@ public class ZeebeSourceConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             "Max jobs to activate")
-        .define(
-            POLL_INTERVAL_CONFIG,
-            Type.LONG,
-            POLL_INTERVAL_DEFAULT,
-            Importance.MEDIUM,
-            WORKER_CONFIG_GROUP,
-            POLL_INTERVAL_DOC,
-            ++order,
-            Width.SHORT,
-            "Poll interval")
         .define(
             JOB_TIMEOUT_CONFIG,
             Type.LONG,

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceInflightRegistry.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceInflightRegistry.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.kafka.connect.source;
+
+import io.zeebe.client.api.response.ActivatedJob;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+class ZeebeSourceInflightRegistry {
+
+  private final Integer maxJobsToActivate;
+  private final List<String> jobTypes;
+  private final Map<String, Integer> inflightJobPerTypeCounts;
+  private final Deque<JobInfo> inflightJobInfoQueue;
+
+  ZeebeSourceInflightRegistry(final ZeebeSourceConnectorConfig config) {
+    maxJobsToActivate = config.getInt(ZeebeSourceConnectorConfig.MAX_JOBS_TO_ACTIVATE_CONFIG);
+    jobTypes = config.getList(ZeebeSourceConnectorConfig.JOB_TYPES_CONFIG);
+    inflightJobPerTypeCounts = new ConcurrentHashMap<>(jobTypes.size());
+    inflightJobInfoQueue = new ArrayDeque<>(maxJobsToActivate * jobTypes.size());
+  }
+
+  boolean hasCapacity() {
+    return jobTypes.stream().anyMatch(this::hasCapacityForType);
+  }
+
+  Stream<String> jobTypesWithCapacity() {
+    return jobTypes.stream().filter(this::hasCapacityForType);
+  }
+
+  int capacityForType(final String jobType) {
+    return maxJobsToActivate - inflightJobPerTypeCounts.getOrDefault(jobType, 0);
+  }
+
+  private boolean hasCapacityForType(final String jobType) {
+    return capacityForType(jobType) > 0;
+  }
+
+  ActivatedJob registerJob(final ActivatedJob job) {
+    inflightJobPerTypeCounts.merge(job.getType(), 0, (k, v) -> v + 1);
+    inflightJobInfoQueue.addLast(new JobInfo(job));
+    return job;
+  }
+
+  long unregisterJob(final long key) {
+    while (!inflightJobInfoQueue.isEmpty()) {
+      final JobInfo jobInfo = inflightJobInfoQueue.pollFirst();
+      inflightJobPerTypeCounts.merge(jobInfo.getJobType(), 1, (k, v) -> v - 1);
+      if (jobInfo.getKey() == key) {
+        break;
+      }
+    }
+    return key;
+  }
+
+  LongStream unregisterAllJobs() {
+    return inflightJobInfoQueue.stream().mapToLong(JobInfo::getKey).map(this::unregisterJob);
+  }
+
+  static class JobInfo {
+    final long key;
+    final String jobType;
+
+    JobInfo(final long key, final String jobType) {
+      this.key = key;
+      this.jobType = jobType;
+    }
+
+    JobInfo(final ActivatedJob job) {
+      this(job.getKey(), job.getType());
+    }
+
+    public long getKey() {
+      return key;
+    }
+
+    String getJobType() {
+      return jobType;
+    }
+
+    @Override
+    public String toString() {
+      return "JobInfo{" + "key=" + key + ", jobType='" + jobType + '\'' + '}';
+    }
+  }
+}

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTask.java
@@ -18,23 +18,17 @@ package io.zeebe.kafka.connect.source;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.ActivatedJob;
-import io.zeebe.client.api.worker.JobClient;
-import io.zeebe.client.api.worker.JobWorker;
 import io.zeebe.kafka.connect.util.ManagedClient;
 import io.zeebe.kafka.connect.util.ManagedClient.AlreadyClosedException;
 import io.zeebe.kafka.connect.util.VersionInfo;
 import io.zeebe.kafka.connect.util.ZeebeClientConfigDef;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -44,42 +38,48 @@ import org.slf4j.LoggerFactory;
 /** Source task for Zeebe which activates jobs, publishes results, and completes jobs */
 public class ZeebeSourceTask extends SourceTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeSourceTask.class);
-  private static final int JOB_QUEUE_TIMEOUT_MS = 5000;
 
-  private String jobHeaderTopic;
   private ManagedClient managedClient;
-  private List<JobWorker> workers;
-  private int maxJobsToActivate;
-  private BlockingQueue<ActivatedJob> jobs;
+  private ZeebeSourceTopicExtractor topicExtractor;
+  private ZeebeSourceTaskFetcher taskFetcher;
+  private ZeebeSourceInflightRegistry inflightRegistry;
+  private ZeebeSourceBackoff backoff;
 
   public ZeebeSourceTask() {}
 
   @Override
   public void start(final Map<String, String> props) {
     final ZeebeSourceConnectorConfig config = new ZeebeSourceConnectorConfig(props);
-    final List<String> jobTypes = config.getList(ZeebeSourceConnectorConfig.JOB_TYPES_CONFIG);
     final ZeebeClient client = buildClient(config);
-
-    maxJobsToActivate = config.getInt(ZeebeSourceConnectorConfig.MAX_JOBS_TO_ACTIVATE_CONFIG);
-    jobs = new ArrayBlockingQueue<>(maxJobsToActivate * jobTypes.size());
-
     managedClient = new ManagedClient(client);
-    workers =
-        jobTypes
-            .stream()
-            .map(type -> this.newWorker(config, type, client))
-            .collect(Collectors.toList());
+
+    topicExtractor = new ZeebeSourceTopicExtractor(config);
+    taskFetcher = new ZeebeSourceTaskFetcher(config, topicExtractor);
+    inflightRegistry = new ZeebeSourceInflightRegistry(config);
+    backoff = new ZeebeSourceBackoff(config);
   }
 
   @SuppressWarnings("squid:S1168")
   @Override
-  public List<SourceRecord> poll() throws InterruptedException {
+  public List<SourceRecord> poll() {
+    if (!inflightRegistry.hasCapacity()) {
+      LOGGER.trace("No capacity left to poll new jobs, returning control to caller after backoff");
+      backoff.backoff();
+      return null;
+    }
+
     final List<SourceRecord> records =
-        drainQueueBlocking().stream().map(this::transformJob).collect(Collectors.toList());
+        inflightRegistry
+            .jobTypesWithCapacity()
+            .flatMap(this::fetchJobs)
+            .map(inflightRegistry::registerJob)
+            .map(this::transformJob)
+            .collect(Collectors.toList());
 
     // poll interface specifies to return null instead of empty
     if (records.isEmpty()) {
-      LOGGER.trace("Nothing to publish, returning control to caller");
+      LOGGER.trace("Nothing to publish, returning control to caller after backoff");
+      backoff.backoff();
       return null;
     }
 
@@ -87,49 +87,53 @@ public class ZeebeSourceTask extends SourceTask {
     return records;
   }
 
+  private Stream<ActivatedJob> fetchJobs(final String jobType) {
+    final int amount = inflightRegistry.capacityForType(jobType);
+    final Duration requestTimeout = backoff.currentDuration();
+    try {
+      return managedClient
+          .withClient(c -> taskFetcher.fetchBatch(c, jobType, amount, requestTimeout))
+          .stream();
+    } catch (AlreadyClosedException | InterruptedException e) {
+      LOGGER.warn(
+          "Expected to activate jobs for type {}, but failed to receive response", jobType, e);
+      return Stream.empty();
+    }
+  }
+
   @Override
   public void stop() {
-    workers.forEach(JobWorker::close);
-    workers.clear();
     managedClient.close();
   }
 
   @Override
-  public void commitRecord(final SourceRecord record) throws InterruptedException {
+  public void commit() {
+    inflightRegistry.unregisterAllJobs().forEach(this::completeJob);
+  }
+
+  @Override
+  public void commitRecord(final SourceRecord record) {
     final long key = (Long) record.sourceOffset().get("key");
+    completeJob(key);
+    inflightRegistry.unregisterJob(key);
+    backoff.reset();
+  }
+
+  private void completeJob(final long key) {
     try {
-      managedClient.withClient(c -> c.newCompleteCommand(key).send().join());
+      managedClient.withClient(c -> c.newCompleteCommand(key).send());
     } catch (final CancellationException e) {
       LOGGER.debug("Complete command cancelled probably because task is stopping", e);
     } catch (final AlreadyClosedException e) {
       LOGGER.debug("Expected to complete job {}, but client is already closed", key);
+    } catch (final InterruptedException e) {
+      LOGGER.debug("Expected to complete job {}, but was interrupted", key);
     }
   }
 
   @Override
   public String version() {
     return VersionInfo.getVersion();
-  }
-
-  private List<ActivatedJob> drainQueueBlocking() throws InterruptedException {
-    final List<ActivatedJob> activatedJobs = new ArrayList<>();
-    boolean jobsAvailable = !jobs.isEmpty();
-
-    // if no jobs available, block a few seconds until we receive one
-    if (!jobsAvailable) {
-      LOGGER.trace("No jobs available, block for {}ms", JOB_QUEUE_TIMEOUT_MS);
-      final ActivatedJob job = jobs.poll(JOB_QUEUE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      if (job != null) {
-        activatedJobs.add(job);
-        jobsAvailable = true;
-      }
-    }
-
-    if (jobsAvailable) {
-      jobs.drainTo(activatedJobs, maxJobsToActivate - 1);
-    }
-
-    return activatedJobs;
   }
 
   private ZeebeClient buildClient(final ZeebeSourceConnectorConfig config) {
@@ -146,7 +150,7 @@ public class ZeebeSourceTask extends SourceTask {
   }
 
   private SourceRecord transformJob(final ActivatedJob job) {
-    final String topic = job.getCustomHeaders().get(jobHeaderTopic);
+    final String topic = topicExtractor.extract(job);
     final Map<String, Integer> sourcePartition =
         Collections.singletonMap("partitionId", decodePartitionId(job.getKey()));
     // a better sourceOffset would be the position but we don't have it here unfortunately
@@ -161,67 +165,6 @@ public class ZeebeSourceTask extends SourceTask {
         job.getKey(),
         Schema.STRING_SCHEMA,
         job.toJson());
-  }
-
-  private JobWorker newWorker(
-      final ZeebeSourceConnectorConfig config, final String type, final ZeebeClient client) {
-    jobHeaderTopic = config.getString(ZeebeSourceConnectorConfig.JOB_HEADER_TOPICS_CONFIG);
-    final List<String> jobVariables =
-        config.getList(ZeebeSourceConnectorConfig.JOB_VARIABLES_CONFIG);
-    final Duration jobTimeout =
-        Duration.ofMillis(config.getLong(ZeebeSourceConnectorConfig.JOB_TIMEOUT_CONFIG));
-    final Duration requestTimeout =
-        Duration.ofMillis(config.getLong(ZeebeClientConfigDef.REQUEST_TIMEOUT_CONFIG));
-    final Duration pollInterval =
-        Duration.ofMillis(config.getLong(ZeebeSourceConnectorConfig.POLL_INTERVAL_CONFIG));
-    final String workerName = config.getString(ZeebeSourceConnectorConfig.WORKER_NAME_CONFIG);
-
-    return client
-        .newWorker()
-        .jobType(type)
-        .handler(this::onJobActivated)
-        .name(workerName)
-        .maxJobsActive(maxJobsToActivate)
-        .requestTimeout(requestTimeout)
-        .timeout(jobTimeout)
-        .pollInterval(pollInterval)
-        .fetchVariables(jobVariables)
-        .open();
-  }
-
-  private boolean isJobInvalid(final ActivatedJob job) {
-    final String topic = job.getCustomHeaders().get(jobHeaderTopic);
-    return topic == null || topic.isEmpty();
-  }
-
-  // eventually allow this behaviour here to be configurable: whether to ignore, fail, or
-  // throw an exception here on invalid jobs
-  // should we block until the request is finished?
-  private Future<Void> handleInvalidJob(final JobClient client, final ActivatedJob job) {
-    LOGGER.debug("Failing invalid job: {}", job);
-    return client
-        .newFailCommand(job.getKey())
-        .retries(job.getRetries() - 1)
-        .errorMessage(
-            String.format(
-                "Expected a kafka topic to be defined as a custom header with key '%s', but none found",
-                jobHeaderTopic))
-        .send();
-  }
-
-  private void onJobActivated(final JobClient client, final ActivatedJob job)
-      throws InterruptedException, AlreadyClosedException {
-    if (isJobInvalid(job)) {
-      managedClient.withClient(c -> handleInvalidJob(c, job));
-    } else {
-      LOGGER.trace("Activating job {}", job);
-      try {
-        jobs.put(job);
-        LOGGER.trace("Activated jobs: {}", jobs.size());
-      } catch (final RuntimeException e) {
-        LOGGER.error("Failed to append job {} to jobs queue", job, e);
-      }
-    }
   }
 
   // Copied from Zeebe Protocol as it is currently fixed to Java 11, and the connector to Java 8

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTaskFetcher.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTaskFetcher.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.kafka.connect.source;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.response.ActivatedJob;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ZeebeSourceTaskFetcher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeSourceTaskFetcher.class);
+
+  private final ZeebeSourceTopicExtractor topicExtractor;
+
+  private final List<String> jobVariables;
+  private final Duration jobTimeout;
+  private final String workerName;
+
+  ZeebeSourceTaskFetcher(
+      final ZeebeSourceConnectorConfig config, final ZeebeSourceTopicExtractor topicExtractor) {
+    this.topicExtractor = topicExtractor;
+
+    jobVariables = config.getList(ZeebeSourceConnectorConfig.JOB_VARIABLES_CONFIG);
+    jobTimeout = Duration.ofMillis(config.getLong(ZeebeSourceConnectorConfig.JOB_TIMEOUT_CONFIG));
+    workerName = config.getString(ZeebeSourceConnectorConfig.WORKER_NAME_CONFIG);
+  }
+
+  List<ActivatedJob> fetchBatch(
+      final ZeebeClient client,
+      final String jobType,
+      final int amount,
+      final Duration requestTimeout) {
+    final Map<Boolean, List<ActivatedJob>> jobs =
+        activateJobs(client, jobType, amount, requestTimeout)
+            .stream()
+            .collect(Collectors.partitioningBy(this::isJobValid));
+
+    final List<ActivatedJob> validJobs = jobs.get(true);
+    final List<ActivatedJob> invalidJobs = jobs.get(false);
+
+    invalidJobs.forEach(j -> handleInvalidJob(client, j));
+
+    return validJobs;
+  }
+
+  private List<ActivatedJob> activateJobs(
+      final ZeebeClient client,
+      final String jobType,
+      final int amount,
+      final Duration requestTimeout) {
+    LOGGER.trace(
+        "Sending activate jobs command for maximal {} jobs of type {} with request timeout {}",
+        amount,
+        jobType,
+        requestTimeout);
+    try {
+      return client
+          .newActivateJobsCommand()
+          .jobType(jobType)
+          .maxJobsToActivate(amount)
+          .workerName(workerName)
+          .timeout(jobTimeout)
+          .fetchVariables(jobVariables)
+          .requestTimeout(requestTimeout)
+          .send()
+          .get()
+          .getJobs();
+    } catch (final InterruptedException | ExecutionException e) {
+      LOGGER.warn(
+          "Expected to fetch maximal {} jobs for type {}, but failed to do so", amount, jobType, e);
+      return Collections.emptyList();
+    }
+  }
+
+  // eventually allow this behaviour here to be configurable: whether to ignore, fail, or
+  // throw an exception here on invalid jobs
+  // should we block until the request is finished?
+  private void handleInvalidJob(final ZeebeClient client, final ActivatedJob job) {
+    final String topicHeaderNotFoundErrorMessage =
+        topicExtractor.getTopicHeaderNotFoundErrorMessage();
+    LOGGER.warn(
+        "{} for job with key {} and type {}",
+        topicHeaderNotFoundErrorMessage,
+        job.getKey(),
+        job.getType());
+    client
+        .newFailCommand(job.getKey())
+        .retries(job.getRetries() - 1)
+        .errorMessage(topicHeaderNotFoundErrorMessage)
+        .send();
+  }
+
+  private boolean isJobValid(final ActivatedJob job) {
+    final String topic = topicExtractor.extract(job);
+    return topic != null && !topic.isEmpty();
+  }
+}

--- a/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTopicExtractor.java
+++ b/src/main/java/io/zeebe/kafka/connect/source/ZeebeSourceTopicExtractor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.kafka.connect.source;
+
+import io.zeebe.client.api.response.ActivatedJob;
+
+public class ZeebeSourceTopicExtractor {
+
+  private final String jobHeaderTopic;
+  private final String topicHeaderNotFoundErrorMessage;
+
+  public ZeebeSourceTopicExtractor(ZeebeSourceConnectorConfig config) {
+    jobHeaderTopic = config.getString(ZeebeSourceConnectorConfig.JOB_HEADER_TOPICS_CONFIG);
+
+    topicHeaderNotFoundErrorMessage =
+        String.format(
+            "Expected a kafka topic to be defined as a custom header with key '%s', but none found",
+            jobHeaderTopic);
+  }
+
+  public String extract(ActivatedJob job) {
+    return job.getCustomHeaders().get(jobHeaderTopic);
+  }
+
+  public String getTopicHeaderNotFoundErrorMessage() {
+    return topicHeaderNotFoundErrorMessage;
+  }
+}

--- a/src/main/java/io/zeebe/kafka/connect/util/ManagedClient.java
+++ b/src/main/java/io/zeebe/kafka/connect/util/ManagedClient.java
@@ -19,6 +19,7 @@ import io.zeebe.client.ZeebeClient;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Wraps a ZeebeClient to provide safe access to it with minimal synchronization.
@@ -41,7 +42,7 @@ public class ManagedClient {
     this.lock = new ReentrantLock();
   }
 
-  public void withClient(final Consumer<ZeebeClient> callback)
+  public <T> T withClient(final Function<ZeebeClient, T> callback)
       throws AlreadyClosedException, InterruptedException {
     if (closed) {
       throw new AlreadyClosedException();
@@ -49,7 +50,7 @@ public class ManagedClient {
 
     lock.lockInterruptibly();
     try {
-      callback.accept(client);
+      return callback.apply(client);
     } finally {
       lock.unlock();
 

--- a/src/main/java/io/zeebe/kafka/connect/util/ZeebeClientConfigDef.java
+++ b/src/main/java/io/zeebe/kafka/connect/util/ZeebeClientConfigDef.java
@@ -16,6 +16,7 @@
 package io.zeebe.kafka.connect.util;
 
 import io.zeebe.client.ClientProperties;
+import java.time.Duration;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -30,7 +31,7 @@ public final class ZeebeClientConfigDef {
   private static final String BROKER_CONTACTPOINT_DEFAULT = "localhost:26500";
   private static final String BROKER_CONTACTPOINT_DOC =
       "Broker contact point, e.g. ``localhost:26500``, for the Zeebe client";
-  private static final long REQUEST_TIMEOUT_DEFAULT = 10_000;
+  private static final long REQUEST_TIMEOUT_DEFAULT = Duration.ofSeconds(1).toMillis();
   private static final String REQUEST_TIMEOUT_DOC =
       "How long to wait before a request to the broker is timed out";
   private static final boolean USE_PLAINTEXT_DEFAULT = false;


### PR DESCRIPTION
- use manual polling instead of job workers
- add backoff which is controlled by inflight requests and does not block
  in case there are still commits going on
- backoff duration is also used for long polling duration and can be limited
  by REQUEST_TIMEOUT_CONFIG
- remove POLL_INTERVAL_CONFIG as it's not needed anymore
- do not sync on job completion, as it's lost completes are handled by Zeebe
  timeout logic and will be retried by kafka after new activation
- add commit callback to complete all inflight jobs on stop of the connector